### PR TITLE
Fix not recognised CSS styles on non-english languages

### DIFF
--- a/config_qm.php
+++ b/config_qm.php
@@ -29,7 +29,7 @@ $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname. ': '. $header);
 $PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
-$PAGE->set_pagetype($blockname);
+$PAGE->set_pagetype(quickmail::PAGE_TYPE);
 
 $changed = false;
 

--- a/email.php
+++ b/email.php
@@ -59,7 +59,7 @@ $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);
 $PAGE->set_url('/blocks/quickmail/email.php', array('courseid' => $courseid));
-$PAGE->set_pagetype($blockname);
+$PAGE->set_pagetype(quickmail::PAGE_TYPE);
 $PAGE->set_pagelayout('standard');
 
 $PAGE->requires->js('/blocks/quickmail/js/jquery.js');

--- a/emaillog.php
+++ b/emaillog.php
@@ -66,7 +66,7 @@ $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);
 $PAGE->set_url('/blocks/quickmail/emaillog.php', array('courseid' => $courseid));
-$PAGE->set_pagetype($blockname);
+$PAGE->set_pagetype(quickmail::PAGE_TYPE);
 
 $dbtable = 'block_quickmail_' . $type;
 

--- a/lib.php
+++ b/lib.php
@@ -3,6 +3,12 @@
 // Written at Louisiana State University
 // 
 abstract class quickmail {
+
+    /**
+     * @const string The page type for this block.
+     */
+    const PAGE_TYPE = 'block-quickmail';
+
     public static function _s($key, $a = null) {
         return get_string($key, 'block_quickmail', $a);
     }

--- a/signature.php
+++ b/signature.php
@@ -45,7 +45,7 @@ $PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_title($title);
 $PAGE->set_heading($title);
-$PAGE->set_pagetype($blockname);
+$PAGE->set_pagetype(quickmail::PAGE_TYPE);
 
 $params = array('userid' => $USER->id);
 $dbsigs = $DB->get_records('block_quickmail_signatures', $params);

--- a/styles.css
+++ b/styles.css
@@ -1,56 +1,56 @@
-#page-blocks-quickmail-admin_email div.region-content table.generaltable {
+#page-block-quickmail-admin_email div.region-content table.generaltable {
    margin: 0 auto 30px auto;
    width: 70%;
 }
 
-#page-Quickmail div.region-content select.select, #page-Quickmail div.region-content table.generaltable, #page-Quickmail div.region-content div.generalbox {
+#page-block-quickmail div.region-content select.select, #page-block-quickmail div.region-content table.generaltable, #page-block-quickmail div.region-content div.generalbox {
    margin-left: 20px;
    margin-right: 20px;
 }
 
-#page-Quickmail select[multiple] {
+#page-block-quickmail select[multiple] {
    min-width: 250px;
    max-width: 250px;
 }
 
-#page-Quickmail .mform {
+#page-block-quickmail .mform {
 }
 
-#page-Quickmail .emailtable {
+#page-block-quickmail .emailtable {
     background-color: inherit;
 }
 
-#page-Quickmail .emailtable .r1 .c0, .emailtable .r1 .c2 {
+#page-block-quickmail .emailtable .r1 .c0, .emailtable .r1 .c2 {
     width: 275px;
 }
 
-#page-Quickmail .object_labels {
+#page-block-quickmail .object_labels {
     margin-right: 20px;
     font-weight: bold;
 }
 
-#page-Quickmail .emailtable .cell {
+#page-block-quickmail .emailtable .cell {
     border: none;
 }
 
-#page-Quickmail .emailtable .r0 .cell {
+#page-block-quickmail .emailtable .r0 .cell {
     padding: .5em .5em .3em .5em;
 }
 
-#page-Quickmail .emailtable .r1 .c1 {
+#page-block-quickmail .emailtable .r1 .c1 {
     text-align: center;
     vertical-align: middle;
 }
 
-#page-Quickmail .emailtable .r1 .c2 div {
+#page-block-quickmail .emailtable .r1 .c2 div {
     padding: 2px 0;
 }
 
-#page-Quickmail .emailtable .r1 .c2, .emailtable .r0 .c1 {
+#page-block-quickmail .emailtable .r1 .c2, .emailtable .r0 .c1 {
     text-align: right;
 }
 
-#page-Quickmail .mform fieldset.hidden>div {
+#page-block-quickmail .mform fieldset.hidden>div {
    clear:both;
    float:none;
    position:center;
@@ -61,11 +61,11 @@
    margin:auto;
 }
 
-#page-Quickmail .mform #add_button, #remove_button, #add_all, #remove_all {
+#page-block-quickmail .mform #add_button, #remove_button, #add_all, #remove_all {
    width: 100px;
    height: 25px;
 }
 
-#page-Quickmail .mform input#id_subject {
+#page-block-quickmail .mform input#id_subject {
   width: 75%;
 }


### PR DESCRIPTION
Currently if we use other language, the CSS on the page is not recognized. This fix this by using a pagetype name who will not be translated. I have replaced also the chosen term in the css file.