### PR TITLE
Fix empty set_url and wrong specified value

### DIFF
--- a/email.php
+++ b/email.php
@@ -51,7 +51,6 @@ $alternates = $DB->get_records_menu('block_quickmail_alternate', $alt_params, ''
 
 $blockname = quickmail::_s('pluginname');
 $header = quickmail::_s('email');
-$returnurl = '/blocks/quickmail/email.php?courseid=' . $courseid;
 
 $PAGE->set_context($context);
 $PAGE->set_course($course);
@@ -59,7 +58,7 @@ $PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);
-$PAGE->set_url('/course/view.php', array('id' => $courseid, 'return' => $returnurl));
+$PAGE->set_url('/blocks/quickmail/email.php', array('courseid' => $courseid));
 $PAGE->set_pagetype($blockname);
 $PAGE->set_pagelayout('standard');
 

--- a/emaillog.php
+++ b/emaillog.php
@@ -65,6 +65,7 @@ $PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_title($blockname . ': ' . $header);
 $PAGE->set_heading($blockname . ': ' . $header);
+$PAGE->set_url('/blocks/quickmail/emaillog.php', array('courseid' => $courseid));
 $PAGE->set_pagetype($blockname);
 
 $dbtable = 'block_quickmail_' . $type;


### PR DESCRIPTION
Its fix the problem when for example we switch lang in the /blocks/quickmail/email.php file and remove the error message caused by missing set_url call in the /blocks/quickmail/emaillog.php