### PR TITLE
block settings: missing block name in the breadcrumb

### DIFF
--- a/config_qm.php
+++ b/config_qm.php
@@ -27,6 +27,7 @@ $PAGE->set_course($course);
 $PAGE->set_url('/blocks/quickmail/config_qm.php', array('courseid' => $courseid));
 $PAGE->set_title($blockname . ': '. $header);
 $PAGE->set_heading($blockname. ': '. $header);
+$PAGE->navbar->add($blockname);
 $PAGE->navbar->add($header);
 $PAGE->set_pagetype($blockname);
 


### PR DESCRIPTION
This fix add the block name in the breadcrumb of the block settings page.